### PR TITLE
Add build support for Windows (Resolves #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Library offers Rust API for [olcPixelGameEngine](https://github.com/OneLoneCoder
 I try keeping the methods and constants similar to the original C++ code so the API feels familiar
 and it is easy to follow along the tutorial videos.
 
-The code builds on Linux and macOS/OSX (any 10.x, including older versions, only X11 is required)
+The code builds on Linux, Windows, and macOS/OSX (any 10.x, including older versions, only X11 is required)
 and uses my mac port of pixel game engine https://github.com/sadikovi/olcPixelGameEngine-macos.
 
 You can link the crate as a dependency and extend `Application` trait to run the pixel game engine:

--- a/build.rs
+++ b/build.rs
@@ -52,6 +52,17 @@ fn build_rust_binding(root: &Path) {
   println!("cargo:rustc-link-lib=stdc++fs");
 }
 
+#[cfg(target_os = "windows")]
+fn build_rust_binding(root: &Path) {
+  cc::Build::new()
+    .cpp(true)
+    .file(root.join("olcRustBindingApp.cpp"))
+    .flag("-std:c++17")
+    .flag("-permissive-")
+    .warnings(false)
+    .compile("olcRustBindingApp");
+}
+
 // macos:
 // g++ -o olcExampleProgram olcExampleProgram.cpp -I/usr/X11/include -L/usr/X11/lib -lX11 -lGL -lpng -lpthread -std=c++17
 //

--- a/cpp/olcRustBindingApp.cpp
+++ b/cpp/olcRustBindingApp.cpp
@@ -138,7 +138,7 @@ void DrawRect(int32_t x, int32_t y, int32_t w, int32_t h, Pixel p) {
   app.DrawRect(x, y, w, h, TO_OLC_PIXEL(p));
 }
 
-void FillRect(int32_t x, int32_t y, int32_t w, int32_t h, Pixel p) {
+void FillRectangle(int32_t x, int32_t y, int32_t w, int32_t h, Pixel p) {
   app.FillRect(x, y, w, h, TO_OLC_PIXEL(p));
 }
 

--- a/cpp/olcRustBindingApp.h
+++ b/cpp/olcRustBindingApp.h
@@ -252,7 +252,7 @@ void FillCircle(int32_t x, int32_t y, int32_t radius, Pixel p);
 // Draws a rectangle at (x,y) to (x+w,y+h)
 void DrawRect(int32_t x, int32_t y, int32_t w, int32_t h, Pixel p);
 // Fills a rectangle at (x,y) to (x+w,y+h)
-void FillRect(int32_t x, int32_t y, int32_t w, int32_t h, Pixel p);
+void FillRectangle(int32_t x, int32_t y, int32_t w, int32_t h, Pixel p);
 // Draws a triangle between points (x1,y1), (x2,y2) and (x3,y3)
 void DrawTriangle(int32_t x1, int32_t y1, int32_t x2, int32_t y2, int32_t x3, int32_t y3, Pixel p);
 // Flat fills a triangle between points (x1,y1), (x2,y2) and (x3,y3)

--- a/src/cpp.rs
+++ b/src/cpp.rs
@@ -253,7 +253,7 @@ extern "C" {
   // Draws a rectangle at (x, y) to (x+w, y+h)
   pub fn DrawRect(x: i32, y: i32, w: i32, h: i32, p: Pixel);
   // Fills a rectangle at (x, y) to (x+w, y+h)
-  pub fn FillRect(x: i32, y: i32, w: i32, h: i32, p: Pixel);
+  pub fn FillRectangle(x: i32, y: i32, w: i32, h: i32, p: Pixel);
   // Draws a triangle between points (x1, y1), (x2, y2) and (x3, y3)
   pub fn DrawTriangle(x1: i32, y1: i32, x2: i32, y2: i32, x3: i32, y3: i32, p: Pixel);
   // Flat fills a triangle between points (x1, y1), (x2, y2) and (x3, y3)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -754,7 +754,7 @@ pub fn draw_rect(x: i32, y: i32, w: i32, h: i32, p: Pixel) {
 
 /// Fills a rectangle at (x, y) to (x+w, y+h).
 pub fn fill_rect(x: i32, y: i32, w: i32, h: i32, p: Pixel) {
-  unsafe { cpp::FillRect(x, y, w, h, p) }
+  unsafe { cpp::FillRectangle(x, y, w, h, p) }
 }
 
 /// Draws a triangle between points (x1, y1), (x2, y2) and (x3, y3).


### PR DESCRIPTION
There was a conflict between the project's FillRect() and the one found in winuser.h. I changed it to FillRectangle(), but the Rust version is still fill_rect() so it won't break anyone's code.